### PR TITLE
[community] ElasticsearchStore: enable max inner product

### DIFF
--- a/libs/community/langchain_community/vectorstores/elasticsearch.py
+++ b/libs/community/langchain_community/vectorstores/elasticsearch.py
@@ -214,6 +214,8 @@ class ApproxRetrievalStrategy(BaseRetrievalStrategy):
             similarityAlgo = "l2_norm"
         elif similarity is DistanceStrategy.DOT_PRODUCT:
             similarityAlgo = "dot_product"
+        elif similarity is DistanceStrategy.MAX_INNER_PRODUCT:
+            similarityAlgo = "max_inner_product"
         else:
             raise ValueError(f"Similarity {similarity} not supported.")
 
@@ -413,7 +415,7 @@ class ElasticsearchStore(VectorStore):
         distance_strategy: Optional. Distance strategy to use when
                             searching the index.
                             Defaults to COSINE. Can be one of COSINE,
-                            EUCLIDEAN_DISTANCE, or DOT_PRODUCT.
+                            EUCLIDEAN_DISTANCE, MAX_INNTER_PRODUCT or DOT_PRODUCT.
 
     If you want to use a cloud hosted Elasticsearch instance, you can pass in the
     cloud_id argument instead of the es_url argument.
@@ -509,6 +511,7 @@ class ElasticsearchStore(VectorStore):
                 DistanceStrategy.COSINE,
                 DistanceStrategy.DOT_PRODUCT,
                 DistanceStrategy.EUCLIDEAN_DISTANCE,
+                DistanceStrategy.MAX_INNER_PRODUCT,
             ]
         ] = None,
         strategy: BaseRetrievalStrategy = ApproxRetrievalStrategy(),
@@ -1104,7 +1107,8 @@ class ElasticsearchStore(VectorStore):
             distance_strategy: Optional. Name of the distance
                                 strategy to use. Defaults to "COSINE".
                                 can be one of "COSINE",
-                                "EUCLIDEAN_DISTANCE", "DOT_PRODUCT".
+                                "EUCLIDEAN_DISTANCE", "DOT_PRODUCT",
+                                "MAX_INNER_PRODUCT".
             bulk_kwargs: Optional. Additional arguments to pass to
                         Elasticsearch bulk.
         """


### PR DESCRIPTION
except for exact strategy, because `maxInnerProduct` is not available as a Painless function:
https://github.com/elastic/elasticsearch/blob/de25e1c3e1b3d42aa95ffd55fbff8caeaadc51e9/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.score.txt#L29

https://www.elastic.co/guide/en/elasticsearch/painless/8.12/painless-api-reference-score.html#_static_methods